### PR TITLE
Added matlab scripts for GICP plane to plane covariance calculation

### DIFF
--- a/MatLab Scripts/plane_to_plane_first_term.m
+++ b/MatLab Scripts/plane_to_plane_first_term.m
@@ -1,0 +1,149 @@
+clc;
+clear; 
+% declare the symbolic variables
+x = sym('x','real');
+y = sym('y','real');
+z = sym('z','real');
+
+a = sym('a','real');
+b = sym('b','real');
+c = sym('c','real');
+
+
+T = [x; y; z;];
+R = [cos(a)*cos(b) cos(a)*sin(b)*sin(c)-sin(a)*cos(c) cos(a)*sin(b)*cos(c)+sin(a)*sin(c);
+     sin(a)*cos(b) sin(a)*sin(b)*sin(c)+cos(a)*cos(c) sin(a)*sin(b)*cos(c)-cos(a)*sin(c);
+     -sin(b)       cos(b)*sin(c)                      cos(b)*cos(c)                      ];
+
+pix = sym('pix','real');
+piy = sym('piy','real');
+piz = sym('piz','real'); 
+
+qix = sym('qix','real');
+qiy = sym('qiy','real');
+qiz = sym('qiz','real');
+ 
+Pi = [pix;piy;piz];
+Qi = [qix;qiy;qiz];
+
+% Cholesky decomposition of GICP information matrix
+lixx = sym('lixx','real');
+lixy = sym('lixy','real');
+lixz = sym('lixz','real');
+liyy = sym('liyy','real');
+liyz = sym('liyz','real');
+lizz = sym('lizz','real');
+Li = [lixx lixy lixz;
+         0 liyy liyz;
+         0    0 lizz];
+
+G = Li * (R * Pi + T - Qi);
+dG_dx = jacobian(G,x);
+dJ_dx = 2 * dG_dx' * G;
+
+dG_dy = jacobian(G,y);
+dJ_dy = 2 * dG_dy' * G;
+
+dG_dz = jacobian(G,z);
+dJ_dz = 2 * dG_dz' * G;
+
+%% 1,2,3
+d2J_dx2 = jacobian(dJ_dx,x)
+d2J_dy2 = jacobian(dJ_dy,y)
+d2J_dz2 = jacobian(dJ_dz,z)
+%% 4,5,6 , 34,35,36
+d2J_dydx = jacobian(dJ_dx,y)
+d2J_dxdy = jacobian(dJ_dy,x)
+
+d2J_dzdx = jacobian(dJ_dx,z)
+d2J_dxdz = jacobian(dJ_dz,x)
+
+d2J_dydz = jacobian(dJ_dz,y)
+d2J_dzdy = jacobian(dJ_dy,z)
+
+%% 7
+dG_da = jacobian(G,a);
+dJ_da = 2 * dG_da' * G;
+d2J_da2 = jacobian(dJ_da,a)
+%% 8
+dG_db = jacobian(G,b);
+dJ_db = 2 * dG_db' * G;
+d2J_db2 = jacobian(dJ_db,b)
+%% 9
+dG_dc = jacobian(G,c);
+dJ_dc = 2 * dG_dc' * G;
+d2J_dc2 = jacobian(dJ_dc,c)
+%% (10,11) , (12,13) , (14,15)
+d2J_dxda = jacobian(dJ_da,x)
+d2J_dadx = jacobian(dJ_dx,a)
+
+d2J_dyda = jacobian(dJ_da,y)
+d2J_dady = jacobian(dJ_dy,a)
+
+d2J_dzda = jacobian(dJ_da,z)
+d2J_dadz = jacobian(dJ_dz,a)
+
+
+%% (16,17), (18,19), (20,21)
+d2J_dxdb = jacobian(dJ_db,x)
+d2J_dbdx = jacobian(dJ_dx,b)
+
+d2J_dydb = jacobian(dJ_db,y)
+d2J_dbdy = jacobian(dJ_dy,b)
+
+d2J_dzdb = jacobian(dJ_db,z)
+d2J_dbdz = jacobian(dJ_dz,b)
+
+%% (22,23) ,(24,25) , (26,27)
+d2J_dxdc = jacobian(dJ_dc,x)
+d2J_dcdx = jacobian(dJ_dx,c)
+
+d2J_dydc = jacobian(dJ_dc,y)
+d2J_dcdy = jacobian(dJ_dy,c)
+
+d2J_dzdc = jacobian(dJ_dc,z)
+d2J_dcdz = jacobian(dJ_dz,c)
+
+%% 28,29 , 30,31,  32,33
+
+d2J_dadb = jacobian(dJ_db,a)
+d2J_dbda = jacobian(dJ_da,b)
+
+d2J_dbdc = jacobian(dJ_dc,b)
+d2J_dcdb = jacobian(dJ_db,c)
+
+d2J_dcda = jacobian(dJ_da,c)
+d2J_dadc = jacobian(dJ_dc,a)
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/MatLab Scripts/plane_to_plane_second_term.m
+++ b/MatLab Scripts/plane_to_plane_second_term.m
@@ -1,0 +1,116 @@
+clc;
+clear; 
+% declare the symbolic variables
+x = sym('x','real');
+y = sym('y','real');
+z = sym('z','real');
+
+a = sym('a','real');
+b = sym('b','real');
+c = sym('c','real');
+
+
+T = [x; y; z;];
+R = [cos(a)*cos(b) cos(a)*sin(b)*sin(c)-sin(a)*cos(c) cos(a)*sin(b)*cos(c)+sin(a)*sin(c);
+     sin(a)*cos(b) sin(a)*sin(b)*sin(c)+cos(a)*cos(c) sin(a)*sin(b)*cos(c)-cos(a)*sin(c);
+     -sin(b)       cos(b)*sin(c)                      cos(b)*cos(c)                      ];
+
+pix = sym('pix','real');
+piy = sym('piy','real');
+piz = sym('piz','real'); 
+
+qix = sym('qix','real');
+qiy = sym('qiy','real');
+qiz = sym('qiz','real');
+ 
+Pi = [pix;piy;piz];
+Qi = [qix;qiy;qiz];
+
+% Cholesky decomposition of GICP information matrix
+lixx = sym('lixx','real');
+lixy = sym('lixy','real');
+lixz = sym('lixz','real');
+liyy = sym('liyy','real');
+liyz = sym('liyz','real');
+lizz = sym('lizz','real');
+Li = [lixx lixy lixz;
+         0 liyy liyz;
+         0    0 lizz];
+
+G = Li * (R * Pi + T - Qi);
+%% small trick
+dG_dT = jacobian(G,T);
+dJ_dT = 2 * dG_dT' * G;
+d2J_dT2 = jacobian(dJ_dT,T);
+
+%%
+dG_dx = jacobian(G,x);
+dG_dy = jacobian(G,y);
+dG_dz = jacobian(G,z);
+dG_da = jacobian(G,a);
+dG_db = jacobian(G,b);
+dG_dc = jacobian(G,c);
+
+dJ_dx = 2 * dG_dx' * G;
+dJ_dy = 2 * dG_dy' * G;
+dJ_dz = 2 * dG_dz' * G;
+dJ_da = 2 * dG_da' * G;
+dJ_db = 2 * dG_db' * G;
+dJ_dc = 2 * dG_dc' * G;
+
+%% Pi
+d2J_dpix_dx = jacobian(dJ_dx, pix)
+d2J_dpix_dy = jacobian(dJ_dy, pix)
+d2J_dpix_dz = jacobian(dJ_dz, pix)
+d2J_dpix_da = jacobian(dJ_da, pix)
+d2J_dpix_db = jacobian(dJ_db, pix)
+d2J_dpix_dc = jacobian(dJ_dc, pix)
+
+d2J_dpiy_dx = jacobian(dJ_dx, piy)
+d2J_dpiy_dy = jacobian(dJ_dy, piy)
+d2J_dpiy_dz = jacobian(dJ_dz, piy)
+d2J_dpiy_da = jacobian(dJ_da, piy)
+d2J_dpiy_db = jacobian(dJ_db, piy)
+d2J_dpiy_dc = jacobian(dJ_dc, piy)
+
+d2J_dpiz_dx = jacobian(dJ_dx, piz)
+d2J_dpiz_dy = jacobian(dJ_dy, piz)
+d2J_dpiz_dz = jacobian(dJ_dz, piz)
+d2J_dpiz_da = jacobian(dJ_da, piz)
+d2J_dpiz_db = jacobian(dJ_db, piz)
+d2J_dpiz_dc = jacobian(dJ_dc, piz)
+
+%% Qi
+d2J_dqix_dx = jacobian(dJ_dx, qix)
+d2J_dqix_dy = jacobian(dJ_dy, qix)
+d2J_dqix_dz = jacobian(dJ_dz, qix)
+d2J_dqix_da = jacobian(dJ_da, qix)
+d2J_dqix_db = jacobian(dJ_db, qix)
+d2J_dqix_dc = jacobian(dJ_dc, qix)
+
+d2J_dqiy_dx = jacobian(dJ_dx, qiy)
+d2J_dqiy_dy = jacobian(dJ_dy, qiy)
+d2J_dqiy_dz = jacobian(dJ_dz, qiy)
+d2J_dqiy_da = jacobian(dJ_da, qiy)
+d2J_dqiy_db = jacobian(dJ_db, qiy)
+d2J_dqiy_dc = jacobian(dJ_dc, qiy)
+
+d2J_dqiz_dx = jacobian(dJ_dx, qiz)
+d2J_dqiz_dy = jacobian(dJ_dy, qiz)
+d2J_dqiz_dz = jacobian(dJ_dz, qiz)
+d2J_dqiz_da = jacobian(dJ_da, qiz)
+d2J_dqiz_db = jacobian(dJ_db, qiz)
+d2J_dqiz_dc = jacobian(dJ_dc, qiz)
+
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
Hello. Was interested in extending your method for GICP (Generalized Iterative Closest Points).

http://www.robots.ox.ac.uk/~avsegal/resources/papers/Generalized_ICP.pdf

This method warps the distance d = R*Pi + T - Qi by information matrix to get the error:

M = inv(CQi + T\*CPi\*T.transpose())
error = d.transpose()*M*d

... where CQi is the uncertainty covariance of the model point and CPi is the uncertainty covariance of the point being registered.

Thought if you take a square root (e.g. cholesky) of the info matrix

M = L.transpose()*L

... then you could use your same method to get covariance for GICP. I haven't tested it yet. Let me know if you're interested in including something like this in your repo and I could develop further.