### PR TITLE
fix d2J_dX2_temp(0,5) element

### DIFF
--- a/C++/src/point_to_plane/cov_func_point_to_plane.h
+++ b/C++/src/point_to_plane/cov_func_point_to_plane.h
@@ -267,7 +267,7 @@ d2J_dxdc    d2J_dydc    d2J_dzdc   d2J_dadc   d2J_dbdc   d2J_dc2
 
         Eigen::MatrixXd d2J_dX2_temp(6,6);
 
-        d2J_dX2_temp << d2J_dx2,     d2J_dydx,	  d2J_dzdx,   d2J_dadx,   d2J_dbdx,     d2J_dzdx,
+        d2J_dX2_temp << d2J_dx2,     d2J_dydx,	  d2J_dzdx,   d2J_dadx,   d2J_dbdx,     d2J_dcdx,
                         d2J_dxdy,    d2J_dy2,	  d2J_dzdy,   d2J_dady,   d2J_dbdy,     d2J_dcdy,
                         d2J_dxdz,    d2J_dydz,    d2J_dz2,    d2J_dadz,   d2J_dbdz,     d2J_dcdz,
                         d2J_dxda,    d2J_dyda,    d2J_dzda,   d2J_da2,	  d2J_dbda,     d2J_dcda,

--- a/C++/src/point_to_point/cov_func_point_to_point.h
+++ b/C++/src/point_to_point/cov_func_point_to_point.h
@@ -265,7 +265,7 @@ d2J_dxdc    d2J_dydc    d2J_dzdc   d2J_dadc   d2J_dbdc   d2J_dc2
 
         Eigen::MatrixXd d2J_dX2_temp(6,6);
 
-        d2J_dX2_temp << d2J_dx2,     d2J_dydx,	  d2J_dzdx,   d2J_dadx,   d2J_dbdx,     d2J_dzdx,
+        d2J_dX2_temp << d2J_dx2,     d2J_dydx,	  d2J_dzdx,   d2J_dadx,   d2J_dbdx,     d2J_dcdx,
                         d2J_dxdy,    d2J_dy2,	  d2J_dzdy,   d2J_dady,   d2J_dbdy,     d2J_dcdy,
                         d2J_dxdz,    d2J_dydz,    d2J_dz2,    d2J_dadz,   d2J_dbdz,     d2J_dcdz,
                         d2J_dxda,    d2J_dyda,    d2J_dzda,   d2J_da2,	  d2J_dbda,     d2J_dcda,


### PR DESCRIPTION
Hello and thank you very much for the covariance of the ICP.
I need this covariance  for a SLAM system and I study this code and your paper.
I notice that element d2J_dX2_temp(0,5) reuses d2J_dzdx instead of d2J_dcdx.
It seems like a minor mistake.

Tavoularis Nikolaos
University of Crete, Forth